### PR TITLE
fix undefined order of maps properties in formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Monkeylang
 
 This is a Rust implementation of the Monkey programming language created by [Thorsten Ball](https://github.com/mrnugget).
-This is a fun project to learn more about interpreters and compilers and to learn Rust Programming Language.
+This is a fun project to learn more about interpreters and compilers and to learn the Rust Programming Language.
 The interpreter is written in pure Rust [without any third party dependencies](https://github.com/nilskch/monkeylang/blob/main/compiler/Cargo.toml).
 
 ## Playground

--- a/compiler/src/ast/expression.rs
+++ b/compiler/src/ast/expression.rs
@@ -6,7 +6,7 @@ use std::{
     fmt::{Display, Formatter, Result, Write},
 };
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum Expression {
     Ident(Identifier),
     Integer(IntegerLiteral),
@@ -146,7 +146,15 @@ impl Expression {
                 } else {
                     let prefix = "\t".repeat(depth + 1);
                     writeln!(output_buffer, "{{").unwrap();
-                    for (idx, (key, value)) in hash_literal.clone().pairs.into_iter().enumerate() {
+
+                    let mut pairs = hash_literal
+                        .clone()
+                        .pairs
+                        .into_iter()
+                        .collect::<Vec<(Expression, Expression)>>();
+                    pairs.sort();
+
+                    for (idx, (key, value)) in pairs.iter().enumerate() {
                         write!(output_buffer, "{}", prefix).unwrap();
                         key.format(output_buffer, depth + 1);
                         write!(output_buffer, ": ").unwrap();
@@ -162,7 +170,7 @@ impl Expression {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Identifier {
     pub token: Token,
     pub value: String,
@@ -180,7 +188,7 @@ impl Identifier {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct IntegerLiteral {
     pub token: Token,
     pub value: i64,
@@ -198,7 +206,7 @@ impl IntegerLiteral {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct StringLiteral {
     pub token: Token,
     pub value: String,
@@ -216,7 +224,7 @@ impl StringLiteral {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct PrefixExpression {
     pub token: Token,
     pub operator: String,
@@ -239,7 +247,7 @@ impl PrefixExpression {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct InfixExpression {
     pub token: Token,
     pub left: Box<Expression>,
@@ -269,7 +277,7 @@ impl InfixExpression {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct BooleanLiteral {
     pub token: Token,
     pub value: bool,
@@ -287,7 +295,7 @@ impl BooleanLiteral {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct IfExpression {
     pub token: Token,
     pub condition: Box<Expression>,
@@ -321,7 +329,7 @@ impl IfExpression {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct FunctionLiteral {
     pub token: Token,
     pub parameters: Vec<Identifier>,
@@ -351,7 +359,7 @@ impl FunctionLiteral {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct CallExpression {
     pub token: Token,
     pub function: Box<Expression>, // Identifier or FunctionLiteral
@@ -381,7 +389,7 @@ impl CallExpression {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ArrayLiteral {
     pub token: Token,
     pub elements: Vec<Expression>,
@@ -406,7 +414,7 @@ impl ArrayLiteral {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Index {
     pub token: Token,
     pub left: Box<Expression>,
@@ -433,6 +441,18 @@ impl Index {
 pub struct HashLiteral {
     pub token: Token,
     pub pairs: HashMap<Expression, Expression>,
+}
+
+impl Ord for HashLiteral {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.token.literal.cmp(&other.token.literal)
+    }
+}
+
+impl PartialOrd for HashLiteral {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl Display for HashLiteral {

--- a/compiler/src/ast/statement.rs
+++ b/compiler/src/ast/statement.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter, Result, Write};
 
 use super::expression::{Expression, Identifier};
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum Statement {
     Let(LetStatement),
     Return(ReturnStatement),
@@ -42,7 +42,7 @@ impl Statement {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct LetStatement {
     pub token: Token,      // token.Let
     pub name: Identifier,  // five
@@ -68,7 +68,7 @@ impl LetStatement {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ReturnStatement {
     pub token: Token,
     pub return_value: Expression,
@@ -96,7 +96,7 @@ impl ReturnStatement {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ExpressionStatement {
     pub token: Token,
     pub expression: Expression,
@@ -125,7 +125,7 @@ impl ExpressionStatement {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct BlockStatement {
     pub token: Token,
     pub statements: Vec<Statement>,

--- a/compiler/src/token.rs
+++ b/compiler/src/token.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter, Result};
 
 pub type TokenPosition = (i64, i64);
 
-#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Ord, PartialOrd)]
 pub enum TokenType {
     Illegal,
     Eof,
@@ -109,7 +109,7 @@ impl Display for TokenType {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Token {
     pub token_type: TokenType,
     pub literal: String,

--- a/web/src/lib/examples.ts
+++ b/web/src/lib/examples.ts
@@ -54,11 +54,11 @@ const maps = `let people = [{
 	"age": 24,
 	"name": "Anna"
 }, {
-	"name": "Bob",
-	"age": 63
+	"age": 63,
+	"name": "Bob"
 }, {
-	"name": "Chris",
-	"age": 16
+	"age": 16,
+	"name": "Chris"
 }];
 
 let getName = fn(person) {
@@ -77,8 +77,8 @@ let map = fn(arr, f) {
 	iter(arr, []);
 };
 
-let peopleArr = map(people, getName);
-print(peopleArr);
+let peopleNames = map(people, getName);
+print(peopleNames);
 `;
 
 export { defaultCode, fibonacci, variables, ifElse, maps };


### PR DESCRIPTION
currently the order of properties in a map is not defined. hence the order changes everytime you format something. This PR creates an order for those properties based on their token literal.